### PR TITLE
Hotfix/0.2.3

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -23,6 +23,8 @@
   "identifier": "com.gohan.rta-todo",
   "plugins": {
     "updater": {
+      "active": true,
+      "dialog": true,
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEI5OTAxRTcxNjY0REI0OTUKUldTVnRFMW1jUjZRdWRKV2ZuT2lQUFJaS1hoRHM0TUY4c1NjeXFoMEFHZFppVldRQ0UwNWVXRVgK",
       "endpoints": [
         "https://github.com/gohan5858/rta-todo/releases/latest/download/latest.json"


### PR DESCRIPTION
Bugfix release

# What's Changed

- Fixed an issue where the automatic update was not functioning correctly

# Download guide

## Windows

- EXE installer: rta-todo_0.2.3_x64-setup.exe
- MSI installer: rta-todo_0.2.3_x64_en-US.msi

## macOS

- Apple Silicon (M1, M2): rta-todo_0.2.3_aarch64.dmg
- Intel Mac: rta-todo_0.2.3_x64.dmg

## Linux

- Red Hat-based: rta-todo-0.2.3-1.x86_64.rpm
- Debian-based: rta-todo_0.2.3_amd64.deb
- All distributions: rta-todo_0.2.3_amd64.AppImage

## Others (compressed files)

- Intel/AMD: rta-todo_x64.app.tar.gz
- ARM: rta-todo_aarch64.app.tar.gz

We also provide signature files (.sig) for each file.
