### PR TITLE
Hotfix/0.3.2

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2709,7 +2709,7 @@ dependencies = [
 
 [[package]]
 name = "rta-todo"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "anyhow-tauri",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rta-todo"
-version = "0.3.1"
+version = "0.3.2"
 description = "An app to complete TODOs with RTA"
 authors = ["gohan5858"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
   },
   "productName": "rta-todo",
   "mainBinaryName": "rta-todo",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "identifier": "com.gohan.rta-todo",
   "plugins": {
     "updater": {


### PR DESCRIPTION
Bugfix release

# What's Changed

- Fixed an issue where the initial required time was not displayed.
- Fixed an issue where the required time and lap time for subtasks were not recorded correctly.

# Download guide

## Windows

- EXE installer: rta-todo_0.3.2_x64-setup.exe
- MSI installer: rta-todo_0.3.2_x64_en-US.msi

## macOS

- Apple Silicon (M1, M2): rta-todo_0.3.2_aarch64.dmg
- Intel Mac: rta-todo_0.3.2_x64.dmg

## Linux

- Red Hat-based: rta-todo-0.3.2-1.x86_64.rpm
- Debian-based: rta-todo_0.3.2_amd64.deb
- All distributions: rta-todo_0.3.2_amd64.AppImage

## Others (compressed files)

- Intel/AMD: rta-todo_x64.app.tar.gz
- ARM: rta-todo_aarch64.app.tar.gz

We also provide signature files (.sig) for each file.
